### PR TITLE
Edited vignette

### DIFF
--- a/vignettes/concordex-demo.Rmd
+++ b/vignettes/concordex-demo.Rmd
@@ -148,7 +148,7 @@ A number greater than 1 means that cells are more likely to have neighbors with 
 While the value is an average over all clusters, the matrix with the values for each cluster is also returned by default, and can be visualized in a heatmap, as a clustering diagnostic:
 
 ```{r, fig.width=4.5, fig.height=4}
-heatConcordex(res, angle_col = 0)
+heatConcordex(res, angle_col = 0, cluster_rows = FALSE, cluster_cols = FALSE)
 ```
 
 This heatmap also indicates good clustering, as almost all neighbors of cells from each of the cluster labels have the same label, on the diagonal. Off diagonal entries should be interpreted as such: (i,j) means the proportion of cells with label i in the neighborhood of cells with label j. Off diagonal entries means ambiguity between labels as similar cells get different labels. As overplotting easily happens on the UMAP plot, this heatmap shows clustering quality more unambiguously than UMAP.

--- a/vignettes/concordex-demo.Rmd
+++ b/vignettes/concordex-demo.Rmd
@@ -93,6 +93,7 @@ plot(attr(reducedDim(sce, "PCA"), "percentVar"), ylab = "Percentage of variance 
 Percentage of variance explained drops sharply from PC1 to PC5, and definitely levels off after PC10, so we use the top 10 PCs for clustering here. The graph based Leiden clustering uses a k nearest neighbor graph. For demonstration here, we use `k = 10`.
 
 ```{r}
+set.seed(29)
 sce$cluster <- clusterRows(reducedDim(sce, "PCA")[,seq_len(10)],
                            NNGraphParam(k = 10, cluster.fun = "leiden",
                                         cluster.args = list(


### PR DESCRIPTION
Used `set.seed` to make sure Leiden clustering is consistent between runs, and not to cluster the heatmap because the text referred to the diagonal and sometimes the clustering moves diagonal entries of the matrix off diagonal in the plot.